### PR TITLE
Sync anaconda.yaml from services

### DIFF
--- a/anaconda.yaml
+++ b/anaconda.yaml
@@ -1,0 +1,4 @@
+anaconda_config_version: 1
+upstream_sources:
+  - pypi:
+      identifier: syncer


### PR DESCRIPTION
Adds or updates `anaconda.yaml` to match `services` on `main`.